### PR TITLE
[bugfix/ELIPSE-772]: Unable to upload images through the TinyMCE Editor

### DIFF
--- a/client/src/components/resource/edit/DocumentInternal.vue
+++ b/client/src/components/resource/edit/DocumentInternal.vue
@@ -19,6 +19,7 @@ import Tinymce from "@/components/Tinymce.vue";
 import tinymce from "tinymce";
 import * as TinyMceUtils from "@/utils/TinyMce";
 import { getUniqueId } from "@/utils/UniqueId";
+import Config from "../../../../config.json";
 
 export default defineComponent({
 	name: "DocumentInternal",
@@ -66,7 +67,7 @@ export default defineComponent({
 			// Set file picker callback
 			const options: any = { ...TinyMceUtils.tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = false;
 			options.height = 400;
 			return options;

--- a/client/src/components/resource/edit/quiz/Hint.vue
+++ b/client/src/components/resource/edit/quiz/Hint.vue
@@ -30,6 +30,7 @@ import { tinyMCEOptions } from "@/utils/TinyMce";
 import { getUniqueId } from "@/utils/UniqueId";
 import { QuestionAdditionalHint } from "@/types/Resource";
 import { defineComponent, PropType } from "vue";
+import Config from "../../../../../config.json";
 export default defineComponent({
 	name: "QuizHint",
 	components: {
@@ -71,7 +72,7 @@ export default defineComponent({
 		tinyMceOptions() {
 			const options: any = { ...tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = true;
 			options.force_br_newlines = false;
 			return options;

--- a/client/src/components/resource/edit/quiz/Module.vue
+++ b/client/src/components/resource/edit/quiz/Module.vue
@@ -92,6 +92,7 @@ import {
 } from "@/types/Resource";
 import { getUniqueId } from "@/utils/UniqueId";
 import { defineComponent, PropType } from "vue";
+import Config from "../../../../../config.json";
 
 export default defineComponent({
 	name: "QuizModule",
@@ -154,7 +155,7 @@ export default defineComponent({
 			// Set file picker callback
 			const options: any = { ...tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = true;
 			return options;
 		},

--- a/client/src/components/resource/edit/quiz/ModuleQuestionInput.vue
+++ b/client/src/components/resource/edit/quiz/ModuleQuestionInput.vue
@@ -29,6 +29,7 @@ import Tinymce from "@/components/Tinymce.vue";
 import { tinyMCEOptions } from "@/utils/TinyMce";
 import { QuestionInputText } from "@/types/Resource";
 import { getUniqueId } from "@/utils/UniqueId";
+import Config from "../../../../../config.json";
 
 export default defineComponent({
 	name: "ModuleQuestionInput",
@@ -67,7 +68,7 @@ export default defineComponent({
 		tinyMceOptions() {
 			const options: any = { ...tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = true;
 			options.force_br_newlines = false;
 			return options;

--- a/client/src/components/resource/edit/quiz/MultipleChoice.vue
+++ b/client/src/components/resource/edit/quiz/MultipleChoice.vue
@@ -91,6 +91,7 @@ import {
 } from "@/types/Resource";
 import { getUniqueId } from "@/utils/UniqueId";
 import { defineComponent, PropType } from "vue";
+import Config from "../../../../../config.json";
 
 export default defineComponent({
 	name: "MultipleChoice",
@@ -167,7 +168,7 @@ export default defineComponent({
 		tinyMceOptions() {
 			const options: any = { ...tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = true;
 			options.force_br_newlines = false;
 			return options;

--- a/client/src/components/resource/edit/quiz/Option.vue
+++ b/client/src/components/resource/edit/quiz/Option.vue
@@ -35,6 +35,7 @@ import { getUniqueId } from "@/utils/UniqueId";
 import { QuestionOption } from "@/types/Resource";
 import { defineComponent } from "vue";
 import { PropType } from "vue";
+import Config from "../../../../../config.json";
 
 export default defineComponent({
 	name: "QuizOption",
@@ -77,7 +78,7 @@ export default defineComponent({
 		tinyMceOptions() {
 			const options: any = { ...tinyMCEOptions };
 			options.file_picker_callback = this.tinyMceFilePicker;
-			options.images_upload_url = this.editorImageUploadApiPath;
+			options.images_upload_url = `${Config.API_URL}/${this.editorImageUploadApiPath}`;
 			options.automatic_uploads = true;
 			options.force_br_newlines = false;
 			return options;


### PR DESCRIPTION
Using config URL for image upload in the TinyMCE editor.

It seems like there was a combination of NGINX and config URLs that was causing this problem.

To test:
1. Go to https://vetshub-uat.uqcloud.net 
2. Go to a test resource or create a hidden resource.
3. Edit or create a quiz and try to upload an image in the editor.
4. Now edit or create a resource and try to add an image in the text editor.