### PR TITLE
[Feature/ELIPSE-785] Remove data manipulation functionality

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,9 @@
 		"watch": "nodemon",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"pretty": "prettier --write ./src",
-		"lint": "eslint ./src --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+		"lint": "eslint ./src --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+		"convertQuiz": "ts-node src/util/QuizConversion.ts",
+		"docker:convertQuiz": "docker exec -it crucible_server_1 sh -c 'yarn convertQuiz'"
 	},
 	"author": "eLIPSE",
 	"license": "MIT",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,8 +13,6 @@ import { setupSessionSerialisation, setupLocalStrategy } from "./auth";
 import { errorHandler } from "./middleware/error";
 import { getEnvironment, getConfig } from "./util/Config";
 import { Database } from "./database";
-import { convertQuiz } from "./util/ConvertQuizzes";
-import { addChildrenTags } from "./util/AddTags";
 
 async function main() {
 	// Get configuration and environment
@@ -93,11 +91,6 @@ async function main() {
 
 	// Listen
 	app.listen(config.SERVER.PORT);
-
-	// Convert any quizzes to new format
-	await convertQuiz();
-	// Apply test tags to resources
-	await addChildrenTags("Test");
 
 	console.info(`Ready and listening on port ${config.SERVER.PORT}`);
 }

--- a/server/src/util/QuizConversion.ts
+++ b/server/src/util/QuizConversion.ts
@@ -1,0 +1,17 @@
+import { convertQuiz } from "../util/ConvertQuizzes";
+import { addChildrenTags } from "../util/AddTags";
+import { Database } from "../database";
+import { getConfig } from "./Config";
+
+const runConvertQuiz = async () => {
+	const config = getConfig();
+	await Database.init(config.DATABASE.URI);
+	// Convert any quizzes to new format
+	await convertQuiz();
+	// Apply test tags to resources
+	await addChildrenTags("Test");
+
+	process.exit(0);
+};
+
+runConvertQuiz();


### PR DESCRIPTION
Removed conversion function from `index.ts` and moved to `util/QuizConversion.ts`.

To test:
1. Get the latest vetshub seed.
2. Restart the server and check no quiz is missing.
3. Now run `yarn docker:convertQuiz` and there should be quiz missing.

Main objective of this ticket is to separate this functionality which has no meaning in the overall application so any issues with the convert quiz should be fixed in a different ticket and investigated why this function was there in the first place.