### PR TITLE
Bugfix/ELIPSE-815 - Unable to upload thumbnail in a collection

### DIFF
--- a/client/cypress/e2e/collection.cy.js
+++ b/client/cypress/e2e/collection.cy.js
@@ -1,36 +1,30 @@
-function generateRandomString(length) {
-  let result = '';
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * characters.length));
-  }
-  return result;
-}
-
-const randomString = generateRandomString(10); // Generates a random string of length 10
-
 describe("Test thumbnail upload in a collection", () => {
-    beforeEach(() => {
+	beforeEach(() => {
 		cy.visit("/");
 		cy.administratorLogin();
 	});
 
-    it("Should be able to upload an thumbnail when creating a collection", () => {
+	it("Should be able to upload an thumbnail when creating a collection", () => {
 		cy.get(".collection-roots > li:nth-child(1) > a:nth-child(1)").click();
 		cy.get('[cy-data="create-resource-button"]').click();
 		cy.get('[cy-data="create-collection-button"]').click();
-		cy.get(
-			'[cy-data="collection-title-field"]').type(randomString);
+		cy.get('[cy-data="collection-title-field"]').type(
+			`Test Collection: ${Math.floor(Math.random() * 100) + 1}`
+		);
 		cy.get(
 			".resource-creator-collection > div:nth-child(4) > label:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > select:nth-child(2)"
 		).select("IMAGE");
-		cy.get('.resource-creator-collection > div:nth-child(4) > label:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > form:nth-child(1) > label:nth-child(1) > input:nth-child(1)')
-		.selectFile("cypress/fixtures/image_test.jpg", { force: true });
+		cy.get(
+			".resource-creator-collection > div:nth-child(4) > label:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > form:nth-child(1) > label:nth-child(1) > input:nth-child(1)"
+		).selectFile("cypress/fixtures/image_test.jpg", { force: true });
 		cy.get('[cy-data="create-button"]').click();
-		cy.intercept('POST', '/api/resource/').as('createQuery');
-        cy.wait('@createQuery');
+		cy.intercept("POST", "/api/resource/").as("createQuery");
+		cy.wait("@createQuery");
 		cy.visit("/");
 		cy.get(".collection-roots > li:nth-child(1) > a:nth-child(1)").click();
-		cy.get('.list-item:last-child > a > .background').should('have.css', 'background-image');
+		cy.get(".list-item:last-child > a > .background").should(
+			"have.css",
+			"background-image"
+		);
 	});
 });

--- a/client/cypress/e2e/collection.cy.js
+++ b/client/cypress/e2e/collection.cy.js
@@ -1,0 +1,36 @@
+function generateRandomString(length) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}
+
+const randomString = generateRandomString(10); // Generates a random string of length 10
+
+describe("Test thumbnail upload in a collection", () => {
+    beforeEach(() => {
+		cy.visit("/");
+		cy.administratorLogin();
+	});
+
+    it("Should be able to upload an thumbnail when creating a collection", () => {
+		cy.get(".collection-roots > li:nth-child(1) > a:nth-child(1)").click();
+		cy.get('[cy-data="create-resource-button"]').click();
+		cy.get('[cy-data="create-collection-button"]').click();
+		cy.get(
+			'[cy-data="collection-title-field"]').type(randomString);
+		cy.get(
+			".resource-creator-collection > div:nth-child(4) > label:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > select:nth-child(2)"
+		).select("IMAGE");
+		cy.get('.resource-creator-collection > div:nth-child(4) > label:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > form:nth-child(1) > label:nth-child(1) > input:nth-child(1)')
+		.selectFile("cypress/fixtures/image_test.jpg", { force: true });
+		cy.get('[cy-data="create-button"]').click();
+		cy.intercept('POST', '/api/resource/').as('createQuery');
+        cy.wait('@createQuery');
+		cy.visit("/");
+		cy.get(".collection-roots > li:nth-child(1) > a:nth-child(1)").click();
+		cy.get('.list-item:last-child > a > .background').should('have.css', 'background-image');
+	});
+});

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -45,6 +45,6 @@ Cypress.Commands.add('administratorLogin', () => {
 
 Cypress.Commands.add('createResource', () => {
     cy.get(".collection-roots > li:nth-child(1) > a:nth-child(1)").click();
-    cy.get("#container > div.top-bar > div.controls > a").click();
+    cy.get('[cy-data="create-resource-button"]').click();
 })
 export {}

--- a/client/src/components/FileSelectorOneWay.vue
+++ b/client/src/components/FileSelectorOneWay.vue
@@ -8,6 +8,7 @@
 					:multiple="multiple"
 					:accept="mimeType"
 					class="input"
+					cy-data="file-selector-input"
 					@change="onFileChange"
 				/>
 				<button

--- a/client/src/components/resource/creator/Collection.vue
+++ b/client/src/components/resource/creator/Collection.vue
@@ -33,6 +33,7 @@
 				<input
 					type="text"
 					v-model="label"
+					cy-data="collection-title-field"
 				/>
 			</label>
 		</div>

--- a/client/src/views/ResourceCreator.vue
+++ b/client/src/views/ResourceCreator.vue
@@ -13,6 +13,7 @@
 					class="toggle-item"
 					:class="activeResourceClass"
 					@click.prevent="switchToResourceCreator"
+					cy-data="create-resource-button"
 				>
 					resource
 				</button>
@@ -21,6 +22,7 @@
 					class="toggle-item"
 					:class="activeCollectionClass"
 					@click.prevent="switchToCollectionCreator"
+					cy-data="create-collection-button"
 				>
 					collection
 				</button>
@@ -38,6 +40,7 @@
 				<h1>New Collection</h1>
 				<button
 					class="button"
+					cy-data="create-button"
 					@click.prevent="uploadCollection"
 				>
 					Create

--- a/client/src/views/ResourceManager.vue
+++ b/client/src/views/ResourceManager.vue
@@ -14,6 +14,7 @@
 					"
 					@click.prevent.stop="createResource"
 					class="button"
+					cy-data="create-resource-button"
 					>Create New
 				</a>
 			</div>

--- a/server/src/routes/api/resource/root.ts
+++ b/server/src/routes/api/resource/root.ts
@@ -12,6 +12,7 @@ import {
 	Type as ResourceType,
 	IResource_Collection,
 	IResource_Collection_Topic_Bundle,
+	IThumbnailData,
 } from "../../../types/resource";
 import {
 	prependPathToFieldname,
@@ -21,6 +22,7 @@ import {
 } from "../../../objectstore/Constants";
 import { convertTree } from "../../../util/GenerateCsv";
 import { getAllResources } from "../../../util/GetAllResource";
+import { getConfig } from "../../../util/Config";
 
 // =============================================================================
 
@@ -106,6 +108,10 @@ export const insertNew: express.RequestHandler = async (req, res, next) => {
 		req,
 		prependPathToFieldname(THUMBNAIL_FILE_FIELDNAME)
 	);
+
+	resource.thumbnail = {
+		url: `${getConfig().MANTA.HOST_URL + uploadThumbnailPath}`,
+	} as IThumbnailData
 
 	if (uploadContentPath !== undefined) {
 		// If there was content that was uploaded, check that the type of


### PR DESCRIPTION
For some reason, the uploaded thumbnail url was not being added as part of the creation.

To test:
- Go to `http://localhost:5173/`
- Press `Create`
- Press `collection`
- Add a title and upload a thumbnail
- Press `save`
- Go to where the resource is located and check if the image thumbnail is upload.

For automation:
- Go to `client` and then run `yarn cypress run --config specPattern=cypress/e2e --spec cypress/e2e/collection.cy.js`